### PR TITLE
Move jasmine-reporters from to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "knockout": "~3.0.0",
-    "jasmine-reporters": "~0.2.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -17,7 +16,8 @@
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.4.3",
     "grunt-jasmine-node": "~0.1.0",
-    "grunt-string-replace": "~0.2.7"
+    "grunt-string-replace": "~0.2.7",
+    "jasmine-reporters": "~0.2.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
jasmine-reporters is not used in shipped code, but is listed as a devdependency in this package.

It should be listed as a devDependency rather than a dependency.